### PR TITLE
[i18n] Add preliminary client-specific strings

### DIFF
--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -44,5 +44,72 @@
     "vi-VN": "Vietnamese",
     "zh-CN": "Simplified Chinese (China)",
     "zh-TW": "Simplified Chinese (Taiwan)"
+  },
+  "client": {
+    "common": {
+      "yes": "Yes",
+      "no": "No",
+      "cancel": "Cancel",
+      "retry": "Retry",
+      "abort": "Abort",
+      "ok": "OK",
+      "delete": "Delete",
+      "remove": "Remove"
+    },
+    "login": {
+      "identity": "Identity",
+      "password": "Password",
+      "loginButton": "Log in",
+      "resetPassword": "Reset password",
+      "errors": {
+        "connectionFailed": "Login failed due to network connection problems.",
+        "incorrectCredentials": "The identity or password provided is incorrect.",
+        "passwordResetDisabled": "The administrator had disabled password reset functionality. Contact them on %s to ask for a new password.",
+        "identityDisabled": "Your identity was disabled.",
+        "identityDisabledWithReason": "Your identity was disabled. Reason: %s",
+        "identityBanned": "Your identity was banned.",
+        "identityBannedWithReason": "Your identity was banned. Reason: %s",
+        "identityTempBannedWithReason": "Your identity was banned till %s. Reason: %s"
+      }
+    },
+    "profileView": {
+      "avatar": "Avatar",
+      "status": "Status",
+    },
+    "settingsView": {
+      "title": "Manage profile",
+
+      "common": {
+        "title": "Common",
+
+        "changePassword": "Change password",
+        "changeDName": "Change display name"
+        "removeAvatar": "Remove avatar",
+        "uploadAvatar": "Upload new avatar",
+      },
+      "connections": {
+        "title": "Connections",
+        "description": "Manage social media connections for this identity",
+        
+        "add": "Add connection",
+
+        "label": "Connection label",
+        "content": "Content",
+      },
+    },
+    "presence": {
+      "offline": "Offline",
+      "invisible": "Invisible",
+      "away": "Away",
+      "dnd": "Do Not Disturb",
+      "online": "Online"
+    },
+    "activityPresence": {
+      "game": "Playing %s",
+      "listening": "Listening to %s",
+      "streaming": "Streaming %s",
+      "streamingDesktop": "Sharing their screen",
+      "streamingDetailed": "Streaming %s on %s"
+    }
   }
 }


### PR DESCRIPTION
# Purpose
Drafting the client's locale strings to have them translated beforehand. Some of them may be changed during development.

# Proposed changes
- Add base en-US strings corresponding to some commonly seen parts of client views.