### PR TITLE
feat: render user status colour on avatars

### DIFF
--- a/sites/app.campground.gg/src/components/UserAvatar.tsx
+++ b/sites/app.campground.gg/src/components/UserAvatar.tsx
@@ -1,5 +1,6 @@
 import { Avatar, Badge, Skeleton, styled } from "@mui/joy";
 import type { SxProps } from "@mui/joy/styles/types";
+import type { ProfileStatus } from "types/campground/user";
 
 const availableBadgeSizes = ["sm", "md", "lg"];
 
@@ -8,7 +9,7 @@ type Props = {
     did: string;
     withStatus?: boolean;
     avatar?: string | null;
-    status?: string | null;
+    status?: ProfileStatus | null;
     size?: Size;
     sx?: SxProps;
     badgeSx?: SxProps;
@@ -22,6 +23,13 @@ const sizeToPx: Record<Size, number> = {
     xxxl: 128,
 };
 
+const statusToBadgeColor: Record<ProfileStatus, "success" | "danger" | "warning" | "neutral"> = {
+    online: "success",
+    donotdisturb: "danger",
+    idle: "warning",
+    offline: "neutral",
+};
+
 const StyledAvatar = styled(Avatar)<{ size?: Size }>(({ theme, size }) => ({
     width: sizeToPx[size ?? "md"],
     height: sizeToPx[size ?? "md"],
@@ -29,7 +37,7 @@ const StyledAvatar = styled(Avatar)<{ size?: Size }>(({ theme, size }) => ({
     // zIndex: 7,
 }));
 
-export default function UserAvatar({ withStatus, avatar, size, badgeSx, sx }: Props) {
+export default function UserAvatar({ withStatus, avatar, status, size, badgeSx, sx }: Props) {
     const sizePx = sizeToPx[size ?? "md"];
     const badgeSize = sizePx * 0.25;
 
@@ -38,7 +46,7 @@ export default function UserAvatar({ withStatus, avatar, size, badgeSx, sx }: Pr
             slotProps={{ badge: { sx: { width: badgeSize, height: badgeSize, } } }}
             anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
             badgeInset={badgeSize / 2}
-            color="success"
+            color={status ? statusToBadgeColor[status] : "success"}
             size={
                 size
                 ? availableBadgeSizes.includes(size)

--- a/sites/app.campground.gg/src/components/UserDisplay.tsx
+++ b/sites/app.campground.gg/src/components/UserDisplay.tsx
@@ -54,7 +54,7 @@ export function UserDisplayNoModal<T extends ProfileViewEmpty>({ onClick,  noUse
         <UserDisplayRoot level="body-md" onClick={onClick}>
             {!noAvatar &&
             <>
-                <UserAvatar withStatus={withStatus} did={user.did} size={avatarSize ?? actualSize} />
+                <UserAvatar withStatus={withStatus} did={user.did} status={(user as ProfileViewBasic)?.status} size={avatarSize ?? actualSize} />
             </>
             }
             {!noUsernameDisplay && <UserDisplayUsername alignItems={align}>

--- a/sites/app.campground.gg/src/components/users/UserHeader.tsx
+++ b/sites/app.campground.gg/src/components/users/UserHeader.tsx
@@ -2,6 +2,7 @@ import { AspectRatio, Skeleton, Box, type Radius } from "@mui/joy";
 import GradientBanner from "../pages/GradientBanner";
 import { Image } from "components";
 import UserAvatar, { UserAvatarSkeleton } from "../UserAvatar";
+import type { ProfileStatus } from "types/campground/user";
 
 export function UserHeaderBanner({ isLoading, src, aspectRatio, borderRadius }: { borderRadius?: keyof Radius; aspectRatio?: number; isLoading?: boolean; did: string; src?: string | null; }) {
     return (
@@ -18,21 +19,21 @@ export function UserHeaderBanner({ isLoading, src, aspectRatio, borderRadius }: 
         </AspectRatio>
     );
 }
-export function UserHeaderAvatar({ isLoading, src, did }: { isLoading?: boolean; did: string; src?: string | null; }) {
+export function UserHeaderAvatar({ isLoading, src, did, status }: { isLoading?: boolean; did: string; src?: string | null; status?: ProfileStatus | null; }) {
     return (
         isLoading
         ? <UserAvatarSkeleton withStatus size="xxl" sx={(theme) => ({ border: `solid 4px ${theme.vars.palette.background.level2}` })} />
-        : <UserAvatar withStatus avatar={src} did={did} size="xxl" sx={(theme) => ({ border: `solid 4px ${theme.vars.palette.neutral.softBg}` })} />
+        : <UserAvatar withStatus avatar={src} did={did} status={status} size="xxl" sx={(theme) => ({ border: `solid 4px ${theme.vars.palette.neutral.softBg}` })} />
     );
 }
-export default function UserHeader({ isLoading, did, banner, avatar, bannerAspectRatio }: { bannerAspectRatio?: number; isLoading?: boolean; did: string; avatar?: string | null; banner?: string | null; }) {
+export default function UserHeader({ isLoading, did, banner, avatar, status, bannerAspectRatio }: { bannerAspectRatio?: number; isLoading?: boolean; did: string; avatar?: string | null; banner?: string | null; status?: ProfileStatus | null; }) {
     return (
         <Box>
             <Box>
                 <UserHeaderBanner isLoading={isLoading} did={did} src={banner} aspectRatio={bannerAspectRatio} />
             </Box>
             <Box sx={{ mt: -6, px: 1.5, zIndex: 2 }}>
-                <UserHeaderAvatar isLoading={isLoading} did={did} src={avatar} />
+                <UserHeaderAvatar isLoading={isLoading} did={did} src={avatar} status={status} />
             </Box>
         </Box>
     );

--- a/sites/app.campground.gg/src/layout/UserProfileCard.tsx
+++ b/sites/app.campground.gg/src/layout/UserProfileCard.tsx
@@ -52,7 +52,7 @@ export default function UserProfileCard<T extends ProfileViewEmpty>({ did, user,
 
     return (
         <UserProfileCardWrapper>
-            <UserHeader did={did} isLoading={isLoading} avatar={fetchedUser?.avatar} banner={fetchedUser?.banner} />
+            <UserHeader did={did} isLoading={isLoading} avatar={fetchedUser?.avatar} banner={fetchedUser?.banner} status={fetchedUser?.status} />
             <Box sx={{ px: 1.5, py: 1 }}>
                 <Stack>
                     <Typography level="title-lg" fontWeight={900}>

--- a/sites/app.campground.gg/src/routes/_global._campsite.c.$campId.t.$tentId/MemberItem.tsx
+++ b/sites/app.campground.gg/src/routes/_global._campsite.c.$campId.t.$tentId/MemberItem.tsx
@@ -127,6 +127,7 @@ export default function MemberItem({
                         size="md"
                         did={member.user.did}
                         avatar={member.user.avatar}
+                        status={member.user.status}
                     />
                 </ListItemDecorator>
                 <ListItemContent>

--- a/sites/app.campground.gg/src/routes/_global.profile.$id/ProfileLayout.tsx
+++ b/sites/app.campground.gg/src/routes/_global.profile.$id/ProfileLayout.tsx
@@ -52,7 +52,7 @@ export default class ProfileLayout extends React.Component<Props> {
                         <UserHeaderBanner did={user.did} aspectRatio={8} src={user.banner} borderRadius="md" />
                     </Box>
                     <ProfileLayoutHeader>
-                        <UserAvatar withStatus did={user.did} size="xxxl" badgeSx={{ "--Badge-ringSize": "4px" }} sx={(theme) => ({ border: `solid 4px ${theme.vars.palette.background.level1}` })} />
+                        <UserAvatar withStatus did={user.did} status={user.status} size="xxxl" badgeSx={{ "--Badge-ringSize": "4px" }} sx={(theme) => ({ border: `solid 4px ${theme.vars.palette.background.level1}` })} />
                         <Stack gap={0} alignItems="center">
                             <Group gap={1} alignItems="center">
                                 <Typography level="h2">{user.displayName}</Typography>

--- a/sites/app.campground.gg/types/campground/user.ts
+++ b/sites/app.campground.gg/types/campground/user.ts
@@ -9,12 +9,14 @@ export interface CampgroundProfileRecord {
     avatar?: string | null;
     banner?: string | null;
 }
+export type ProfileStatus = "online" | "donotdisturb" | "idle" | "offline";
 export interface ProfileViewEmpty {
     did: string;
     handle: string;
 }
 export interface ProfileViewBasic extends ProfileViewEmpty {
     displayName?: string | null;
+    status?: ProfileStatus | null;
     
     description?: string | null;
     tagline?: string | null;


### PR DESCRIPTION
Part of #20.

## Summary

- Add `ProfileStatus` type (`online` / `donotdisturb` / `idle` / `offline`) and a `status` field to `ProfileViewBasic`, matching the `profileStatus` enum in the `gg.campground.actor.defs` lexicon
- `UserAvatar` now honours its `status` prop instead of always rendering a green badge: online → success (green), donotdisturb → danger (red), idle → warning (yellow), offline → neutral (grey). Previously the prop was accepted but ignored
- Thread `status` through the call sites that already hold profile view data: `UserDisplay`, `UserHeader` / `UserProfileCard`, `MemberItem`, `ProfileLayout`

## Notes

The backend does not serve `status` in profile views yet, so this is frontend groundwork: once the API returns it, the badges pick it up with no further changes. Call sites without profile view data (e.g. the global nav, which holds a `CampgroundProfileRecord`) keep the previous behaviour — green badge when `withStatus` is set. A status picker/setter will need an XRPC endpoint first.

## Verification

- `tsc -p tsconfig.app.json --noEmit`: identical error set before and after the change (the repo has pre-existing type errors on `dev`; none added or removed)
- `eslint` on the touched files: only pre-existing findings