### PR TITLE
fix(app): dedupe react and mui instances in vite

### DIFF
--- a/sites/app.campground.gg/vite.config.ts
+++ b/sites/app.campground.gg/vite.config.ts
@@ -5,6 +5,9 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    dedupe: ["react", "react-dom", "@mui/joy", "@emotion/react", "@emotion/styled"],
+  },
   plugins: [reactRouter(), tsconfigPaths(), viteStaticCopy({
       targets: [
         {


### PR DESCRIPTION
## Summary
- `packages/components` carries its own `node_modules`, so the app resolved two copies of `react`, `react-dom`, `@mui/joy`, and `@emotion/*`
- The duplicate instances crashed the client in `Layout` with invalid hook calls / hook context mismatches
- Adds `resolve.dedupe` to the app vite config so a single copy of each is used

## Test plan
- [x] App boots at http://localhost:5173 with zero console errors (previously crashed immediately in `Layout`)
- [ ] Maintainers: `npm run dev` in `sites/app.campground.gg` and confirm the client renders